### PR TITLE
Redirect stdout and stderr to client

### DIFF
--- a/kernel.py
+++ b/kernel.py
@@ -35,6 +35,7 @@ class OurZMQInteractiveShell(ZMQInteractiveShell):
     """
     Overwrite for the embedding case.
     Also see InteractiveShellEmbed for reference.
+    py> `exit(keep_kernel=False)` or `exit(0)` to kill kernel thread
     """
 
     def init_sys_modules(self):
@@ -43,9 +44,9 @@ class OurZMQInteractiveShell(ZMQInteractiveShell):
     def init_prompts(self):
         pass
 
-    def exiter(self):
+    def exiter(self, keep_kernel=True):
         # See ZMQExitAutocall.
-        self.keepkernel_on_exit = True
+        self.keepkernel_on_exit = keep_kernel
         self.ask_exit()
 
 
@@ -167,6 +168,7 @@ class IPythonBackgroundKernelWrapper:
         import atexit
         from ipykernel import write_connection_file
         atexit.register(self._cleanup_connection_file)
+        atexit.register(self._reset_io)
         write_connection_file(self.connection_filename, key=self._session.key, **self._connection_info)
         # The key should be secret, to only allow the same user to connect.
         # Make sure the permissions are set accordingly.
@@ -249,7 +251,7 @@ class IPythonBackgroundKernelWrapper:
         loop.add_callback(self._start_kernel)
         try:
             loop.start()
-        except KeyboardInterrupt:
+        except (KeyboardInterrupt, SystemExit):
             pass
 
     def start(self):

--- a/kernel.py
+++ b/kernel.py
@@ -7,7 +7,6 @@ import logging
 # ZMQStream wants a Tornado IOLoop, not a asyncio loop.
 from tornado import ioloop
 from ipykernel.ipkernel import IPythonKernel, ZMQInteractiveShell
-
 from ipykernel.iostream import OutStream
 
 try:
@@ -104,7 +103,7 @@ class IPythonBackgroundKernelWrapper:
     def _init_io(self):
         """
         Redirect stdout to iopub socket
-        call me after loging conection file
+        call me after logging connection file
         """
         self._stdout_save, self._stderr_save = sys.stdout, sys.stderr
         sys.stdout = OutStream(self._session, self._iopub_socket, 'stdout')
@@ -233,7 +232,6 @@ class IPythonBackgroundKernelWrapper:
 
         self._logger.info("IPython: Start kernel now. pid: %i, thread: %r" % (os.getpid(), threading.current_thread()))
         self._init_io()
-
         self._kernel.start()
 
     def _tornado_handle_callback_exception(self, callback):

--- a/kernel.py
+++ b/kernel.py
@@ -249,7 +249,7 @@ class IPythonBackgroundKernelWrapper:
         loop.add_callback(self._start_kernel)
         try:
             loop.start()
-        except (KeyboardInterrupt, SystemExit):
+        except KeyboardInterrupt:
             pass
 
     def start(self):

--- a/main.py
+++ b/main.py
@@ -30,6 +30,7 @@ def _main():
     arg_parser = argparse.ArgumentParser()
     arg_parser.add_argument("--no_connection_fn_with_pid", action="store_true")
     arg_parser.add_argument("--debug_embed", action="store_true")
+    arg_parser.add_argument("--redirect_stdio", action="store_true")
     args = arg_parser.parse_args()
 
     if args.debug_embed:
@@ -38,7 +39,8 @@ def _main():
 
     init_ipython_kernel(
         user_ns={"demo_var": 42},
-        connection_fn_with_pid=not args.no_connection_fn_with_pid)
+        connection_fn_with_pid=not args.no_connection_fn_with_pid,
+        redirect_stdio=args.redirect_stdio)
 
     # Do nothing. Keep main thread alive, as IPython kernel lives in a daemon thread.
     # This is just a demo. Normally you would have your main loop in the main thread.


### PR DESCRIPTION
Instead of getting them in the old `sys.stdout`
Fix part1 of issue #2 
![ipy_thread](https://user-images.githubusercontent.com/6123962/73584741-38a09100-4479-11ea-8827-fb16554ff5aa.png)
