### PR TITLE
Write connection file in jupyter dir if present && shorten log output

### DIFF
--- a/kernel.py
+++ b/kernel.py
@@ -212,14 +212,10 @@ class IPythonBackgroundKernelWrapper:
         # Make sure the permissions are set accordingly.
         os.chmod(self.connection_filename, os.stat(self.connection_filename).st_mode & 0o0700)
 
-        def shorten_filename(runtime_file):
-            """Shorten connection filename kernel-24536.json -> 24536"""
-            r_cfile = r'.*kernel-([^\-]*).*\.json'
-            return re.sub(r_cfile, r'\1', runtime_file)
-
+        # Log connection advice to stdout
         fname_log = self.connection_filename
         if self._should_reduce_filename:
-            fname_log = shorten_filename(fname_log)
+            fname_log = re.sub(r'.*kernel-([^\-]*).*\.json', r'\1', fname_log)
         self._logger.info(
             "To connect another client to this IPython kernel, use: "
             "jupyter console --existing %s", fname_log)

--- a/kernel.py
+++ b/kernel.py
@@ -274,8 +274,9 @@ class IPythonBackgroundKernelWrapper:
         self._setup_streams()
         self._create_kernel()
 
-        self._logger.info("IPython: Start kernel now. pid: %i, thread: %r",
-                          os.getpid(), threading.current_thread())
+        self._logger.info(
+            "IPython: Start kernel now. pid: %i, thread: %r",
+            os.getpid(), threading.current_thread())
         if self._redirect_stdio:
             import atexit
             self._init_io()


### PR DESCRIPTION
Fix part2 of #2:
The connection file are written in the current directory which could be annoying.
If jupyter is present, it can give a default data path.
![ipy_thread_filename](https://user-images.githubusercontent.com/6123962/73585114-b74afd80-447c-11ea-8fda-3ddeb44f4a72.png)

You can see that the ls (top right) do not show any `kernel-*.json` and the `--existing` advice (bottom left) is shortened to the only required pid (proof right).
Also, you can see print as no return because it is another PR to follow the Minimum Viable Change philosophy