### PR TITLE
Add support for ipykernel 6

### DIFF
--- a/kernel.py
+++ b/kernel.py
@@ -4,9 +4,11 @@ import os
 import sys
 import threading
 import logging
+from packaging import version
 # Note: IPython uses zmq.eventloop.zmqstream.ZMQStream, see IPythonKernel.
 # ZMQStream wants a Tornado IOLoop, not a asyncio loop.
 from tornado import ioloop
+import ipykernel
 from ipykernel.ipkernel import IPythonKernel, ZMQInteractiveShell
 from ipykernel.iostream import OutStream
 
@@ -254,7 +256,9 @@ class IPythonBackgroundKernelWrapper:
         config.HistoryAccessor.connection_options = dict(check_same_thread=False)
         kernel = OurIPythonKernel(
             session=self._session,
-            shell_streams=[self._shell_stream, self._control_stream],
+            **(dict(shell_stream=self._shell_stream, control_stream=self._control_stream)
+               if version.parse(ipykernel.__version__) >= version.parse('6.0')
+               else dict(shell_streams=[self._shell_stream, self._control_stream])),
             iopub_socket=self._iopub_socket,
             log=self._logger,
             user_ns=self.user_ns,


### PR DESCRIPTION
In ipykernel 6, the shell_streams argument for the Kernel is deprecated. When
a list of shell_streams is provided, only the first one is actually used in
ipykernel 6, i.e. the control stream is not setup properly.
The shell_stream and control_stream are individual argument for the Kernel in
ipykernel 6.

Compatibilty with ipykernel 5 is preserved, but might be dropped later.

Upstream change:
https://github.com/ipython/ipykernel/blob/7ed57cb4a03e719074c373029cf9f2e6dfd2c6de/ipykernel/kernelbase.py#L75

Should solve the following issue:
https://github.com/albertz/background-zmq-ipython/issues/6