### PR TITLE
Simplify dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-jupyter
+jupyter-console
+jupyter_client
+jupyter_core
 ipykernel
 tornado
 pyzmq


### PR DESCRIPTION
The whole `jupyter` is not necessary to run this, just these 3 appear to suffice. (tested in a virtual environment, but looks like jupyter is not really well-isolated so jupyter-console seems to still work in the virtual environment even though it's not installed in there, not sure)

The latter 2 is a dependency of `ipykernel` in fact.